### PR TITLE
Support for projects nested under subdirectories

### DIFF
--- a/src/main/scala/com/hpe/sbt/ValidatePullRequest.scala
+++ b/src/main/scala/com/hpe/sbt/ValidatePullRequest.scala
@@ -196,10 +196,10 @@ object ValidatePullRequest extends AutoPlugin {
         .flatMap(project => project.base.relativeTo(rootBaseDir)
           .map { relativePath =>
             val projRef = ProjectRef(extracted.structure.root, project.id)
-            if (relativePath.getName == "") {
+            if (relativePath.getPath == "") {
               "" -> projRef
             } else {
-              relativePath.getName + "/" -> projRef
+              relativePath.getPath + "/" -> projRef
             }
           }
         ).sortBy(_._1)

--- a/src/sbt-test/sbt-pull-request-validator/build-subdirectories/.gitignore
+++ b/src/sbt-test/sbt-pull-request-validator/build-subdirectories/.gitignore
@@ -1,0 +1,3 @@
+target/
+global/
+project/build.properties

--- a/src/sbt-test/sbt-pull-request-validator/build-subdirectories/build.sbt
+++ b/src/sbt-test/sbt-pull-request-validator/build-subdirectories/build.sbt
@@ -1,0 +1,22 @@
+name := "root-project"
+
+lazy val a = project.in(file("modules/a"))
+  .settings(commonSettings)
+lazy val b = project.in(file("modules/b")).dependsOn(a)
+  .settings(commonSettings)
+lazy val c = project.in(file("modules/c"))
+  .settings(commonSettings)
+lazy val d = project.in(file("modules/extra-dir/d")).dependsOn(a)
+  .settings(commonSettings)
+
+lazy val root = project.in(file(".")).settings(commonSettings).aggregate(a, b, c, d)
+
+val detectRun = taskKey[Unit]("")
+def commonSettings = Seq(
+  detectRun := {
+    val targetFile = target.value / "ran"
+    IO.write(targetFile, "Test ran")
+  },
+  prValidatorTasks := Seq(detectRun)
+)
+ThisBuild / prValidatorTargetBranch := "targetBranch"

--- a/src/sbt-test/sbt-pull-request-validator/build-subdirectories/project/plugins.sbt
+++ b/src/sbt-test/sbt-pull-request-validator/build-subdirectories/project/plugins.sbt
@@ -1,0 +1,1 @@
+addSbtPlugin("com.hpe.sbt" % "sbt-pull-request-validator" % sys.props("plugin.version"))

--- a/src/sbt-test/sbt-pull-request-validator/build-subdirectories/test
+++ b/src/sbt-test/sbt-pull-request-validator/build-subdirectories/test
@@ -1,0 +1,17 @@
+$ exec git init .
+$ exec git add .
+$ exec git commit -m Test
+$ exec git branch targetBranch
+
+$ touch modules/a/foo.txt
+
+$ exec git add .
+$ exec git commit -m Updated
+
+> validatePullRequest
+
+$ exists modules/a/target/ran
+$ exists modules/b/target/ran
+-$ exists modules/c/target/ran
+$ exists modules/extra-dir/d/target/ran
+-$ exists target/ran


### PR DESCRIPTION
For our build, our projects are all nested under a `modules` directory to keep the top level clean.  This adds support for building projects that are nested under subdirectories.