### PR TITLE
Update sbt version

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -2,6 +2,7 @@ lazy val `sbt-pull-request-validator` = (project in file("."))
   .enablePlugins(AutomateHeaderPlugin)
 
 sbtPlugin := true
+enablePlugins(SbtPlugin)
 
 organization := "com.hpe.sbt"
 
@@ -36,7 +37,7 @@ releaseProcess := Seq[ReleaseStep](
   commitReleaseVersion,
   tagRelease,
   releaseStepCommandAndRemaining("publish"),
-  releaseStepTask(bintrayRelease in `sbt-pull-request-validator`),
+  releaseStepTask(`sbt-pull-request-validator` / bintrayRelease),
   setNextVersion,
   commitNextVersion,
   pushChanges

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.1.5
+sbt.version=1.9.7

--- a/src/main/scala/com/hpe/sbt/ValidatePullRequest.scala
+++ b/src/main/scala/com/hpe/sbt/ValidatePullRequest.scala
@@ -134,10 +134,10 @@ object ValidatePullRequest extends AutoPlugin {
   private def pullRequestId = jenkinsPullRequestId orElse travisPullRequestId
 
   override lazy val buildSettings = Seq(
-    includeFilter in validatePullRequest := "*",
-    excludeFilter in validatePullRequest := "README.*",
-    includeFilter in validatePullRequestBuildAll := PathGlobFilter("project/**") || PathGlobFilter("*.sbt"),
-    excludeFilter in validatePullRequestBuildAll := NothingFilter,
+    validatePullRequest / includeFilter := "*",
+    validatePullRequest / excludeFilter := "README.*",
+    validatePullRequestBuildAll / includeFilter := PathGlobFilter("project/**") || PathGlobFilter("*.sbt"),
+    validatePullRequestBuildAll / excludeFilter := NothingFilter,
     prValidatorSourceBranch := {
       localSourceBranch orElse jenkinsSourceBranch getOrElse "HEAD"
     },
@@ -198,7 +198,7 @@ object ValidatePullRequest extends AutoPlugin {
 
       val state = Keys.state.value
       val extracted = Project.extract(state)
-      val rootBaseDir = (baseDirectory in ThisBuild).value
+      val rootBaseDir = (ThisBuild / baseDirectory).value
       // All projects in reverse order of path, this ensures when we search through them, we get the most specific
       // first
       val projects = extracted.structure.allProjects
@@ -217,9 +217,9 @@ object ValidatePullRequest extends AutoPlugin {
         .sortBy(_._1)
         .reverse
 
-      val filter = (includeFilter in validatePullRequest).value -- (excludeFilter in validatePullRequest).value
+      val filter = (validatePullRequest / includeFilter).value -- (validatePullRequest / excludeFilter).value
       val allBuildFilter =
-        (includeFilter in validatePullRequestBuildAll).value -- (excludeFilter in validatePullRequestBuildAll).value
+        (validatePullRequestBuildAll / includeFilter).value -- (validatePullRequestBuildAll / excludeFilter).value
 
       log.info(s"Diffing [$prId] to determine changed modules in PR...")
       val diffOutput = s"git diff $target --name-only".!!.split("\n")
@@ -289,7 +289,7 @@ object ValidatePullRequest extends AutoPlugin {
         Seq()
       }
     },
-    prValidatorTasks := Seq(test in Test),
+    prValidatorTasks := Seq(Test / test),
     prValidatorBuildAllTasks := prValidatorTasks.value,
     prValidatorEnforcedBuildAllTasks := prValidatorBuildAllTasks.value,
     validatePullRequest := Def.taskDyn {

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "1.0.1-SNAPSHOT"
+ThisBuild / version := "1.0.1-SNAPSHOT"


### PR DESCRIPTION
Updates SBT to 1.9.7 (I opted for this instead of 1.9.8 because 1.9.8 has some known issues) while also getting rid of deprecated `in` syntax. Existing sbt scripted tests pass locally after this change (there aren't any standard tests).

After this PR is merged I will integrate [sbt-github-actions](https://github.com/sbt/sbt-github-actions) so we can get some CI (will also remove travis CI).