### PR TITLE
Error if plugin version isn't defined in scripted tests

### DIFF
--- a/src/sbt-test/sbt-pull-request-validator/build-all/project/plugins.sbt
+++ b/src/sbt-test/sbt-pull-request-validator/build-all/project/plugins.sbt
@@ -1,1 +1,5 @@
-addSbtPlugin("com.github.sbt" % "sbt-pull-request-validator" % sys.props("plugin.version"))
+sys.props.get("plugin.version") match {
+  case Some(x) => addSbtPlugin("com.github.sbt" % "sbt-pull-request-validator" % x)
+  case _ => sys.error("""|The system property 'plugin.version' is not defined.
+                         |Specify this property using the scriptedLaunchOpts -D.""".stripMargin)
+}

--- a/src/sbt-test/sbt-pull-request-validator/build-changed/project/plugins.sbt
+++ b/src/sbt-test/sbt-pull-request-validator/build-changed/project/plugins.sbt
@@ -1,1 +1,5 @@
-addSbtPlugin("com.github.sbt" % "sbt-pull-request-validator" % sys.props("plugin.version"))
+sys.props.get("plugin.version") match {
+  case Some(x) => addSbtPlugin("com.github.sbt" % "sbt-pull-request-validator" % x)
+  case _ => sys.error("""|The system property 'plugin.version' is not defined.
+                         |Specify this property using the scriptedLaunchOpts -D.""".stripMargin)
+}

--- a/src/sbt-test/sbt-pull-request-validator/build-subdirectories/project/plugins.sbt
+++ b/src/sbt-test/sbt-pull-request-validator/build-subdirectories/project/plugins.sbt
@@ -1,1 +1,5 @@
-addSbtPlugin("com.github.sbt" % "sbt-pull-request-validator" % sys.props("plugin.version"))
+sys.props.get("plugin.version") match {
+  case Some(x) => addSbtPlugin("com.github.sbt" % "sbt-pull-request-validator" % x)
+  case _ => sys.error("""|The system property 'plugin.version' is not defined.
+                         |Specify this property using the scriptedLaunchOpts -D.""".stripMargin)
+}

--- a/src/sbt-test/sbt-pull-request-validator/filters/project/plugins.sbt
+++ b/src/sbt-test/sbt-pull-request-validator/filters/project/plugins.sbt
@@ -1,1 +1,5 @@
-addSbtPlugin("com.github.sbt" % "sbt-pull-request-validator" % sys.props("plugin.version"))
+sys.props.get("plugin.version") match {
+  case Some(x) => addSbtPlugin("com.github.sbt" % "sbt-pull-request-validator" % x)
+  case _ => sys.error("""|The system property 'plugin.version' is not defined.
+                         |Specify this property using the scriptedLaunchOpts -D.""".stripMargin)
+}


### PR DESCRIPTION
This is the standard way you should add the projects dependency in scripted plugins