### PR TITLE
Use single snapshot version

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -23,6 +23,22 @@ scriptedLaunchOpts ++= Seq(
   "-Dplugin.version=" + version.value
 )
 
+// So that publishLocal doesn't continuously create new versions
+def versionFmt(out: sbtdynver.GitDescribeOutput): String = {
+  val snapshotSuffix =
+    if (out.isSnapshot()) "-SNAPSHOT"
+    else ""
+  out.ref.dropPrefix + snapshotSuffix
+}
+
+def fallbackVersion(d: java.util.Date): String = s"HEAD-${sbtdynver.DynVer timestamp d}"
+
+ThisBuild / version := dynverGitDescribeOutput.value.mkVersion(versionFmt, fallbackVersion(dynverCurrentDate.value))
+ThisBuild / dynver := {
+  val d = new java.util.Date
+  sbtdynver.DynVer.getGitDescribeOutput(d).mkVersion(versionFmt, fallbackVersion(d))
+}
+
 ThisBuild / githubWorkflowBuild := Seq(WorkflowStep.Sbt(List("test", "scripted")))
 
 ThisBuild / githubWorkflowTargetTags ++= Seq("v*")


### PR DESCRIPTION
This trick is generally used in sbt plugins which use sbt-dynver that have scripted tests. Its means that whenever scripted tests run `publishLocal` it doesn't generate a new version and hence a new local publish every time which over time can pollute your local ivy repository.

In other words the version is just now

```
<@sbt-pull-request-validator>-<⎇ use-single-snapshot-version>-> sbt version
[info] welcome to sbt 1.9.7 (Amazon.com Inc. Java 1.8.0_402)
[info] loading global plugins from /Users/mdedetrich/.sbt/1.0/plugins
[info] loading settings for project sbt-pull-request-validator-build from plugins.sbt ...
[info] loading project definition from /Users/mdedetrich/github/sbt-pull-request-validator/project
[info] loading settings for project sbt-pull-request-validator from build.sbt ...
[info] set current project to sbt-pull-request-validator (in build file:/Users/mdedetrich/github/sbt-pull-request-validator/)
[info] 1.0.0-SNAPSHOT
```