### PR TITLE
Rename com.hpe.sbt to com.github.sbt.pullrequestvalidator

### DIFF
--- a/src/main/scala/com/github/sbt/pullrequestvalidator/ValidatePullRequest.scala
+++ b/src/main/scala/com/github/sbt/pullrequestvalidator/ValidatePullRequest.scala
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package com.hpe.sbt
+package com.github.sbt.pullrequestvalidator
 
 import java.util.regex.Pattern
 

--- a/src/main/scala/com/hpe/sbt/package.scala
+++ b/src/main/scala/com/hpe/sbt/package.scala
@@ -1,0 +1,6 @@
+package com.hpe
+
+package object sbt {
+  @deprecated("com.github.sbt.pullrequestvalidator.ValidatePullRequest", "2.0.0")
+  val ValidatePullRequest = com.github.sbt.pullrequestvalidator.ValidatePullRequest
+}


### PR DESCRIPTION
Resolves: https://github.com/sbt/sbt-pull-request-validator/issues/22

Additionally I also placed the package into a nested `pullrequestvalidator` since this seems to be standard for sbt community plugins.