### PR TITLE
Upgrade sbt header

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ project/plugins/project/
 .history
 .cache
 .lib/
+.bsp/
 
 ### Scala template
 *.class

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,6 +1,6 @@
 libraryDependencies += "org.scala-sbt" %% "scripted-plugin" % sbtVersion.value
 
 addSbtPlugin("com.github.sbt"    % "sbt-ci-release"     % "1.5.12")
-addSbtPlugin("de.heikoseeberger" % "sbt-header"         % "5.0.0")
+addSbtPlugin("de.heikoseeberger" % "sbt-header"         % "5.10.0")
 addSbtPlugin("org.scalameta"     % "sbt-scalafmt"       % "2.5.2")
 addSbtPlugin("com.github.sbt"    % "sbt-github-actions" % "0.22.0")


### PR DESCRIPTION
Since I started to block `repo.scala-sbt.org` and `repo.typesafe.com` in my `/etc/hosts` sbt failed to download sbt-header 5.0.0 because that version is hosted in the former repo.