### PR TITLE
Use `macos-12` because JDK 8 and sbt not available on `macos-latest` anymore

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
     name: Build and Test
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest]
+        os: [ubuntu-latest, macos-12]
         scala: [2.12.19]
         java: [temurin@8, temurin@11, temurin@17, temurin@21]
     runs-on: ${{ matrix.os }}

--- a/build.sbt
+++ b/build.sbt
@@ -86,7 +86,7 @@ ThisBuild / githubWorkflowPublish := Seq(
   )
 )
 
-ThisBuild / githubWorkflowOSes := Seq("ubuntu-latest", "macos-latest")
+ThisBuild / githubWorkflowOSes := Seq("ubuntu-latest", "macos-12")
 
 ThisBuild / githubWorkflowJavaVersions := Seq(
   JavaSpec.temurin("8"),


### PR DESCRIPTION
* `macos-latest` [just recently](https://github.com/actions/runner-images/pull/9642/files) got upgraded to use the _macOS 14 Arm64_ image.
  * You can see that recent change [here](https://github.com/actions/runner-images/pull/9601/files), also GitHub announced that in their blog [here](https://github.blog/changelog/2024-04-01-macos-14-sonoma-is-generally-available-and-the-latest-macos-runner-image/).
* Before `macos-latest` was referencing the _macOS 12 x64_ image.

This change however now causes two problems:
1. The `actions/setup-java@v4` can not install Java 8 anymore on this macOS Arm64 image, because there are no Temurin 8 JDK packages available, you can check that easily [here](https://adoptium.net/temurin/releases/?os=mac&arch=aarch64&version=8&package=jdk) (which in the background uses the same API to fetch the desired versions like `actions/setup-java@v4` uses). Also, checking the [_Temurin™ Supported Platforms_ page](https://adoptium.net/supported-platforms/) under its section _macOS (Apple Silicon)_ confirms that.

2. Unfortunately, as of today, the GitHub Actions macOS 14 runner images (as well as the macOS 13 ones) do not provide `sbt`, see its README [here](https://github.com/actions/runner-images/blob/main/images/macos/macos-14-arm64-Readme.md). The macOS 12 runner images however did provide sbt, see [here](https://github.com/actions/runner-images/blob/main/images/macos/macos-12-Readme.md).

So the easiest thing to keep testing with Java 8 on macOS currently is to stay on `macos-12` for now.

I did open requests to add `sbt` to the macOS 14 images (both Arm64 and x64), see
- https://github.com/actions/runner-images/issues/9837
- https://github.com/actions/runner-images/pull/9830

Once `sbt` is availabe for the `macos-latest` image, we could make use of it, but exclude Java8 on macOS from testing:
```diff
iff --git a/.github/workflows/ci.yml b/.github/workflows/ci.yml
index 51613a4..459b99c 100644
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,6 +25,9 @@ jobs:
         os: [ubuntu-latest, macos-latest]
         scala: [2.12.19]
         java: [temurin@8, temurin@11, temurin@17, temurin@21]
+        exclude:
+          - java: temurin@8
+            os: macos-latest
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout current branch (full)
diff --git a/build.sbt b/build.sbt
index 201af9e..c3ae705 100644
--- a/build.sbt
+++ b/build.sbt
@@ -95,6 +95,9 @@ ThisBuild / githubWorkflowJavaVersions := Seq(
   JavaSpec.temurin("21")
 )
 
+ThisBuild / githubWorkflowBuildMatrixExclusions +=
+  MatrixExclude(Map("java" -> "temurin@8", "os" -> "macos-latest"))
+
 // Necessary to setup git so that sbt-scripted tests can run on github actions
 ThisBuild / githubWorkflowBuildPreamble := Seq(
   WorkflowStep.Run(
```