### PR TITLE
CI: Use `macos-latest`, exclude `temurin@8`/`macos-latest` and manually install `sbt`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,9 +22,12 @@ jobs:
     name: Build and Test
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-12]
+        os: [ubuntu-latest, macos-latest]
         scala: [2.12.19]
         java: [temurin@8, temurin@11, temurin@17, temurin@21]
+        exclude:
+          - java: temurin@8
+            os: macos-latest
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout current branch (full)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,6 +67,10 @@ jobs:
           java-version: 21
           cache: sbt
 
+      - name: Install sbt
+        if: matrix.os == 'macos-latest'
+        run: brew install sbt
+
       - name: Setup git
         run: |
           git config --global init.defaultBranch main

--- a/build.sbt
+++ b/build.sbt
@@ -86,7 +86,7 @@ ThisBuild / githubWorkflowPublish := Seq(
   )
 )
 
-ThisBuild / githubWorkflowOSes := Seq("ubuntu-latest", "macos-12")
+ThisBuild / githubWorkflowOSes := Seq("ubuntu-latest", "macos-latest")
 
 ThisBuild / githubWorkflowJavaVersions := Seq(
   JavaSpec.temurin("8"),
@@ -94,6 +94,9 @@ ThisBuild / githubWorkflowJavaVersions := Seq(
   JavaSpec.temurin("17"),
   JavaSpec.temurin("21")
 )
+
+ThisBuild / githubWorkflowBuildMatrixExclusions +=
+  MatrixExclude(Map("java" -> "temurin@8", "os" -> "macos-latest"))
 
 // Necessary to setup git so that sbt-scripted tests can run on github actions
 ThisBuild / githubWorkflowBuildPreamble := Seq(

--- a/build.sbt
+++ b/build.sbt
@@ -98,8 +98,19 @@ ThisBuild / githubWorkflowJavaVersions := Seq(
 ThisBuild / githubWorkflowBuildMatrixExclusions +=
   MatrixExclude(Map("java" -> "temurin@8", "os" -> "macos-latest"))
 
+// GitHub Actions macOS 13+ runner images do not come with sbt preinstalled anymore
+ThisBuild / githubWorkflowBuildPreamble ++= Seq(
+  WorkflowStep.Run(
+    commands = List(
+      "brew install sbt"
+    ),
+    cond = Some("matrix.os == 'macos-latest'"),
+    name = Some("Install sbt")
+  )
+)
+
 // Necessary to setup git so that sbt-scripted tests can run on github actions
-ThisBuild / githubWorkflowBuildPreamble := Seq(
+ThisBuild / githubWorkflowBuildPreamble ++= Seq(
   WorkflowStep.Run(
     commands = List(
       "git config --global init.defaultBranch main",


### PR DESCRIPTION
- Works around https://github.com/actions/setup-java/issues/627

`macos-latest` does not provide `sbt` and JDK 8 anymore, see
- https://github.com/actions/runner-images/issues/9837
- https://github.com/actions/runner-images/issues/9369
- https://github.com/sbt/sbt-pull-request-validator/pull/42